### PR TITLE
Fixed token passing during login and authentication

### DIFF
--- a/apps/frontend/src/shared/hooks/useAuthFlow.ts
+++ b/apps/frontend/src/shared/hooks/useAuthFlow.ts
@@ -57,9 +57,14 @@ export function useAuthFlow({ liffId, autoRun = true }: Options) {
 				setStep("redirecting");
 				return;
 			}
+			if (vres.next !== "LOGIN" || !vres.token) {
+				setError("Unexpected verify result");
+				setStep("error");
+				return;
+			}
 
 			setStep("logging-internal");
-			const lres = await login();
+			const lres = await login({ jwt: vres.token });
 
 			if (!lres.ok) {
 				setError(lres.message || "login failed");
@@ -69,7 +74,7 @@ export function useAuthFlow({ liffId, autoRun = true }: Options) {
 
 			if (lres.next === "AUTO") {
 				setStep("getting-info");
-				const meres = await me();
+				const meres = await me({ jwt: lres.token });
 				if (!meres.ok) {
 					setError(meres.message || "Failed to fetch user profile");
 					setStep("error");
@@ -112,7 +117,7 @@ export function useAuthFlow({ liffId, autoRun = true }: Options) {
 					return;
 				}
 				setStep("getting-info");
-				const meres = await me();
+				const meres = await me({ jwt: sres.token });
 				if (!meres.ok) {
 					setError(meres.message || "Failed to fetch user profile");
 					setStep("error");

--- a/apps/frontend/src/shared/hooks/useLogin.ts
+++ b/apps/frontend/src/shared/hooks/useLogin.ts
@@ -13,42 +13,45 @@ import { postLogin } from "../api/login/api";
 
 export function useLogin() {
 	const dispatch = useDispatch();
-	const { jwt } = useSelector((state: RootState) => state.authToken);
+	// const { jwt } = useSelector((state: RootState) => state.authToken);
 
-	const login = useCallback(async (): Promise<
-		LoginResponse | ErrorResponse
-	> => {
-		try {
-			if (typeof window === "undefined") {
-				throw new Error("useLogin must be used in a browser context");
-			}
-			if (!jwt) {
-				throw new Error("JWT is required for login");
-			}
+	const login = useCallback(
+		async ({
+			jwt,
+		}: { jwt: string }): Promise<LoginResponse | ErrorResponse> => {
+			try {
+				if (typeof window === "undefined") {
+					throw new Error("useLogin must be used in a browser context");
+				}
+				if (!jwt) {
+					throw new Error("JWT is required for login");
+				}
 
-			const res = await postLogin(jwt);
-			if ("ok" in res && res.ok === false && "message" in res) {
-				throw new Error(res.message || "login failed");
-			}
+				const res = await postLogin(jwt);
+				if ("ok" in res && res.ok === false && "message" in res) {
+					throw new Error(res.message || "login failed");
+				}
 
-			if (res?.next === "SELECT_STORE") {
-				dispatch(setStores(res.stores));
-				return res;
-			}
+				if (res?.next === "SELECT_STORE") {
+					dispatch(setStores(res.stores));
+					return res;
+				}
 
-			if (res?.next === "AUTO") {
-				dispatch(setAuthToken({ jwt: res.token }));
-				return res;
-			}
+				if (res?.next === "AUTO") {
+					dispatch(setAuthToken({ jwt: res.token }));
+					return res;
+				}
 
-			throw new Error("Unexpected login response");
-		} catch (error) {
-			if (error instanceof Error) {
-				return { ok: false, message: error.message };
+				throw new Error("Unexpected login response");
+			} catch (error) {
+				if (error instanceof Error) {
+					return { ok: false, message: error.message };
+				}
+				return { ok: false, message: "Unexpected error during login" };
 			}
-			return { ok: false, message: "Unexpected error during login" };
-		}
-	}, [dispatch, jwt]);
+		},
+		[dispatch],
+	);
 
 	return { login };
 }

--- a/apps/frontend/src/shared/hooks/useMe.ts
+++ b/apps/frontend/src/shared/hooks/useMe.ts
@@ -20,48 +20,53 @@ export function useMe() {
 	const [getting, setGetting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
-	const { jwt } = useSelector((state: RootState) => state.authToken);
+	// const { jwt } = useSelector((state: RootState) => state.authToken);
 
-	const me = useCallback(async (): Promise<
-		AuthMeResponse | ErrorResponse | ValidationErrorResponse
-	> => {
-		setGetting(true);
-		setError(null);
-		if (typeof window === "undefined") {
-			throw new Error("useLiffVerify must be used in a browser context");
-		}
-
-		if (!jwt) {
-			throw new Error("JWT is required for login");
-		}
-
-		try {
-			const res = await getMe(jwt);
-			if ("ok" in res && res.ok === false) {
-				setError(res.message);
-				return res;
+	const me = useCallback(
+		async ({
+			jwt,
+		}: { jwt: string }): Promise<
+			AuthMeResponse | ErrorResponse | ValidationErrorResponse
+		> => {
+			setGetting(true);
+			setError(null);
+			if (typeof window === "undefined") {
+				throw new Error("useLiffVerify must be used in a browser context");
 			}
 
-			dispatch(
-				setUser({
-					id: res.user.id,
-					name: res.user.name,
-					pictureUrl: res.user.pictureUrl,
-					role: res.role,
-				}),
-			);
-			dispatch(setStore(res.store));
-			dispatch(setActiveShiftRequests(res.ActiveShiftRequests));
+			if (!jwt) {
+				throw new Error("JWT is required for login");
+			}
 
-			return res;
-		} catch (e) {
-			const msg = e instanceof Error ? e.message : "Unexpected error";
-			setError(msg);
-			return { ok: false, message: msg };
-		} finally {
-			setGetting(false);
-		}
-	}, [dispatch, jwt]);
+			try {
+				const res = await getMe(jwt);
+				if ("ok" in res && res.ok === false) {
+					setError(res.message);
+					return res;
+				}
+
+				dispatch(
+					setUser({
+						id: res.user.id,
+						name: res.user.name,
+						pictureUrl: res.user.pictureUrl,
+						role: res.role,
+					}),
+				);
+				dispatch(setStore(res.store));
+				dispatch(setActiveShiftRequests(res.ActiveShiftRequests));
+
+				return res;
+			} catch (e) {
+				const msg = e instanceof Error ? e.message : "Unexpected error";
+				setError(msg);
+				return { ok: false, message: msg };
+			} finally {
+				setGetting(false);
+			}
+		},
+		[dispatch],
+	);
 
 	return { me, getting, error };
 }


### PR DESCRIPTION
## エラー
- reduxの反映より先にフックが呼び出されるため、トークンがnull状態になり、受け渡しエラーが出ていた。

## 改善
- reduxに保存はしつつ、フックの返り値からトークンを取得し、次に呼び出すフックの引数にセットした。